### PR TITLE
Town Hall v2 — stained glass, columns, carpet, chandelier

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -1260,7 +1260,7 @@ function createInterior(type, w, h, furniture) {
   tileMap[h-1][doorX] = T.PATH;
   if (w > 6) tileMap[h-1][doorX+1] = T.PATH;
   // Mark furniture as solid (except walkable/decorative items)
-  const walkable=new Set(['chair','rug','wall_sconce','bar_stool','stage_floor','town_seal','wall_clock']);
+  const walkable=new Set(['chair','rug','wall_sconce','bar_stool','stage_floor','town_seal','wall_clock','hall_carpet','chandelier']);
   for (const f of furniture) {
     if (!walkable.has(f.item)) tileMap[f.y][f.x] = T.WALL;
   }
@@ -1324,32 +1324,37 @@ function generateInteriors() {
     {x:7,y:4,item:'workbench'},
   ]);
   INTERIOR_MAPS.hall = createInterior('hall', 14, 12, [
-    // ═══ BACK WALL — Mayor's desk, bookshelves, art ═══
-    {x:1,y:1,item:'bookshelf'},{x:2,y:1,item:'bookshelf'},
-    {x:3,y:1,item:'portrait_toshi'},
-    {x:5,y:1,item:'mayor_desk'},{x:6,y:1,item:'mayor_desk'},{x:7,y:1,item:'mayor_desk'},{x:8,y:1,item:'mayor_desk'},
-    {x:10,y:1,item:'whitepaper'},
-    {x:11,y:1,item:'bookshelf'},{x:12,y:1,item:'bookshelf'},
-    // Mayor's chair + lectern
-    {x:6,y:2,item:'chair'},{x:7,y:2,item:'lectern'},
-    // Filing cabinets along sides
-    {x:1,y:3,item:'filing_cabinet'},{x:12,y:3,item:'filing_cabinet'},
-    // Village map on left wall
-    {x:1,y:5,item:'village_map'},
-    // ═══ TOWN SEAL on floor (walkable) ═══
-    {x:6,y:4,item:'town_seal'},{x:7,y:4,item:'town_seal'},
-    {x:6,y:5,item:'town_seal'},{x:7,y:5,item:'town_seal'},
-    // ═══ COUNCIL SEATING — rows of benches facing the desk ═══
-    {x:3,y:6,item:'council_bench'},{x:5,y:6,item:'council_bench'},
-    {x:8,y:6,item:'council_bench'},{x:10,y:6,item:'council_bench'},
-    {x:3,y:8,item:'council_bench'},{x:5,y:8,item:'council_bench'},
-    {x:8,y:8,item:'council_bench'},{x:10,y:8,item:'council_bench'},
-    // Wall sconces for atmosphere
-    {x:1,y:7,item:'wall_sconce'},{x:12,y:7,item:'wall_sconce'},
-    // Notice board + ballot box near entrance
-    {x:1,y:10,item:'notice_board'},{x:12,y:10,item:'ballot_box'},
-    // Clock above door
-    {x:6,y:10,item:'wall_clock'},
+    // ═══ BACK WALL — stained glass centrepiece ═══
+    {x:1,y:1,item:'bookshelf'},{x:2,y:1,item:'portrait_toshi'},
+    {x:5,y:1,item:'stained_glass'},{x:6,y:1,item:'stained_glass'},
+    {x:7,y:1,item:'stained_glass'},{x:8,y:1,item:'stained_glass'},
+    {x:11,y:1,item:'whitepaper'},{x:12,y:1,item:'bookshelf'},
+    // ═══ MAYOR'S DAIS — raised desk area ═══
+    {x:5,y:2,item:'mayor_desk'},{x:6,y:2,item:'mayor_desk'},
+    {x:7,y:2,item:'mayor_desk'},{x:8,y:2,item:'mayor_desk'},
+    {x:7,y:3,item:'lectern'},
+    // ═══ STONE COLUMNS — civic grandeur ═══
+    {x:1,y:3,item:'column'},{x:12,y:3,item:'column'},
+    {x:1,y:8,item:'column'},{x:12,y:8,item:'column'},
+    // ═══ RED CARPET RUNNER — down the centre aisle ═══
+    {x:6,y:4,item:'hall_carpet'},{x:7,y:4,item:'hall_carpet'},
+    {x:6,y:5,item:'hall_carpet'},{x:7,y:5,item:'hall_carpet'},
+    {x:6,y:6,item:'hall_carpet'},{x:7,y:6,item:'hall_carpet'},
+    {x:6,y:7,item:'hall_carpet'},{x:7,y:7,item:'hall_carpet'},
+    {x:6,y:8,item:'hall_carpet'},{x:7,y:8,item:'hall_carpet'},
+    {x:6,y:9,item:'hall_carpet'},{x:7,y:9,item:'hall_carpet'},
+    // ═══ COUNCIL PEWS — facing the desk ═══
+    {x:3,y:5,item:'council_bench'},{x:4,y:5,item:'council_bench'},
+    {x:9,y:5,item:'council_bench'},{x:10,y:5,item:'council_bench'},
+    {x:3,y:7,item:'council_bench'},{x:4,y:7,item:'council_bench'},
+    {x:9,y:7,item:'council_bench'},{x:10,y:7,item:'council_bench'},
+    // ═══ ATMOSPHERE ═══
+    {x:1,y:5,item:'wall_sconce'},{x:12,y:5,item:'wall_sconce'},
+    {x:1,y:9,item:'wall_sconce'},{x:12,y:9,item:'wall_sconce'},
+    // Chandelier glow in centre (walkable ceiling decoration)
+    {x:6,y:6,item:'chandelier'},{x:7,y:6,item:'chandelier'},
+    // Entrance area
+    {x:1,y:10,item:'village_map'},{x:12,y:10,item:'ballot_box'},
   ]);
 }
 
@@ -3100,7 +3105,7 @@ function update(dt) {
           interiorNPCs.push({ name:'Barkeep', x:3*TILE+8, y:3*TILE+8, col:'#8B6340', hair:'#2A1A08',
             dlg:['"Welcome to the Hodl Tavern. What\'ll it be?"','"We only serve Bitcoin-branded beverages here."','"Your uncle used to sit right where you\'re standing."','"Lightning tips accepted and appreciated."'] });
         } else if (buildingType === 'hall') {
-          interiorNPCs.push({ name:'Mayor Keynesian', x:6*TILE+8, y:3*TILE+8, col:'#888', hair:'#AAA',
+          interiorNPCs.push({ name:'Mayor Keynesian', x:6*TILE+8, y:4*TILE+8, col:'#555580', hair:'#AAA',
             dlg:['"Ah, you\'ve come to discuss village policy?"','"I\'ve been thinking about a new stimulus package..."','"The village budget is... flexible. Very flexible."','"Don\'t listen to the hermit. The system works fine."'] });
         }
       });
@@ -5155,7 +5160,7 @@ function draw(){
   } else {
     for(const f of interior.furniture) {
       // Floor-level items draw on the ground layer (y=0) so entities walk over them
-      const groundItems=new Set(['rug','stage_floor','town_seal']);
+      const groundItems=new Set(['rug','stage_floor','town_seal','hall_carpet','chandelier']);
       const fy=groundItems.has(f.item)?0:f.y*TILE+TILE;
       entities.push({y:fy, draw:()=>drawDecor({type:'furniture',item:f.item,x:f.x,y:f.y})});
     }

--- a/web/game_render.js
+++ b/web/game_render.js
@@ -1347,6 +1347,105 @@ function drawDecor(d) {
       ctx.fillRect(fx+ST-10,fy+7,1,5);ctx.fillRect(fx+ST-12,fy+9,5,1);
       ctx.fillStyle='#CC3030';ctx.fillRect(fx+ST-10,fy+6,1,2); // N pointer
     }
+    else if(d.item==='stained_glass'){
+      // ── STAINED GLASS WINDOW — glowing ₿ design ──────────────
+      const ft=_now/2000;
+      // Stone frame
+      ctx.fillStyle='#505058';ctx.fillRect(fx,fy,ST,ST);
+      ctx.fillStyle='#606068';ctx.fillRect(fx+2,fy+2,ST-4,ST-4);
+      // Glass panes — deep saturated colours with glow
+      ctx.fillStyle='#1A1A6A';ctx.fillRect(fx+4,fy+4,ST-8,ST-8); // deep blue base
+      // Coloured segments
+      ctx.fillStyle='rgba(180,40,40,0.6)';ctx.fillRect(fx+4,fy+4,(ST-8)/2,ST-8); // red left
+      ctx.fillStyle='rgba(40,40,180,0.6)';ctx.fillRect(fx+ST/2,fy+4,(ST-8)/2,ST-8); // blue right
+      ctx.fillStyle='rgba(40,140,40,0.5)';ctx.fillRect(fx+8,fy+ST/2-4,ST-16,8); // green band
+      ctx.fillStyle='rgba(220,180,40,0.5)';ctx.fillRect(fx+ST/2-4,fy+6,8,ST-12); // gold cross
+      // Lead lines
+      ctx.fillStyle='#404048';
+      ctx.fillRect(fx+ST/2-1,fy+4,2,ST-8); // vertical
+      ctx.fillRect(fx+4,fy+ST/2-1,ST-8,2); // horizontal
+      ctx.fillRect(fx+4,fy+12,ST-8,1);ctx.fillRect(fx+4,fy+ST-14,ST-8,1);
+      // ₿ in the centre (golden, glowing)
+      ctx.fillStyle='rgba(247,147,26,0.8)';
+      ctx.font=`bold 14px ${FONT}`;ctx.textAlign='center';
+      ctx.fillText('₿',fx+ST/2,fy+ST/2+5);
+      // Light pouring through (animated)
+      const glow=0.04+Math.sin(ft)*0.02;
+      ctx.fillStyle=`rgba(255,220,140,${glow})`;
+      ctx.fillRect(fx-4,fy+ST,ST+8,ST*2); // light beam below window
+      ctx.fillStyle=`rgba(200,100,100,${glow*0.5})`;
+      ctx.fillRect(fx,fy+ST,ST/2,ST*1.5);
+      ctx.fillStyle=`rgba(100,100,200,${glow*0.5})`;
+      ctx.fillRect(fx+ST/2,fy+ST,ST/2,ST*1.5);
+    }
+    else if(d.item==='column'){
+      // ── STONE COLUMN — classical pillar ───────────────────────
+      ctx.fillStyle='rgba(0,0,0,0.1)';ctx.beginPath();ctx.ellipse(fx+ST/2,fy+ST-2,10,4,0,0,Math.PI*2);ctx.fill();
+      // Base (wider)
+      ctx.fillStyle='#707078';ctx.fillRect(fx+ST/2-10,fy+ST-8,20,8);
+      ctx.fillStyle='#808088';ctx.fillRect(fx+ST/2-9,fy+ST-7,18,6);
+      // Shaft
+      ctx.fillStyle='#8A8A92';ctx.fillRect(fx+ST/2-7,fy+6,14,ST-14);
+      ctx.fillStyle='#9A9AA2';ctx.fillRect(fx+ST/2-6,fy+7,12,ST-16);
+      // Fluting (vertical grooves)
+      ctx.fillStyle='rgba(0,0,0,0.08)';
+      ctx.fillRect(fx+ST/2-4,fy+8,2,ST-18);
+      ctx.fillRect(fx+ST/2+2,fy+8,2,ST-18);
+      // Highlight
+      ctx.fillStyle='rgba(255,255,255,0.12)';
+      ctx.fillRect(fx+ST/2-5,fy+8,2,ST-18);
+      // Capital (wider top)
+      ctx.fillStyle='#808088';ctx.fillRect(fx+ST/2-10,fy+2,20,6);
+      ctx.fillStyle='#9090A0';ctx.fillRect(fx+ST/2-9,fy+3,18,4);
+      // Scroll detail on capital
+      ctx.fillStyle='#A0A0B0';
+      ctx.beginPath();ctx.arc(fx+ST/2-7,fy+5,3,0,Math.PI*2);ctx.fill();
+      ctx.beginPath();ctx.arc(fx+ST/2+7,fy+5,3,0,Math.PI*2);ctx.fill();
+    }
+    else if(d.item==='hall_carpet'){
+      // ── RED HALL CARPET — rich crimson with gold edges ─────────
+      const hasN=interior&&interior.furniture.some(f=>f.item==='hall_carpet'&&f.x===d.x&&f.y===d.y-1);
+      const hasS=interior&&interior.furniture.some(f=>f.item==='hall_carpet'&&f.x===d.x&&f.y===d.y+1);
+      const hasW=interior&&interior.furniture.some(f=>f.item==='hall_carpet'&&f.x===d.x-1&&f.y===d.y);
+      const hasE=interior&&interior.furniture.some(f=>f.item==='hall_carpet'&&f.x===d.x+1&&f.y===d.y);
+      // Rich crimson base
+      ctx.fillStyle='#7A1818';ctx.fillRect(fx,fy,ST,ST);
+      ctx.fillStyle='#8A2020';ctx.fillRect(fx+1,fy+1,ST-2,ST-2);
+      // Gold border trim on outer edges
+      ctx.fillStyle='#C8A040';
+      if(!hasN){ ctx.fillRect(fx,fy,ST,3); ctx.fillStyle='#AA8830';ctx.fillRect(fx+1,fy+1,ST-2,1); }
+      if(!hasS){ ctx.fillStyle='#C8A040';ctx.fillRect(fx,fy+ST-3,ST,3); ctx.fillStyle='#AA8830';ctx.fillRect(fx+1,fy+ST-2,ST-2,1); }
+      if(!hasW){ ctx.fillStyle='#C8A040';ctx.fillRect(fx,fy,3,ST); ctx.fillStyle='#AA8830';ctx.fillRect(fx+1,fy+1,1,ST-2); }
+      if(!hasE){ ctx.fillStyle='#C8A040';ctx.fillRect(fx+ST-3,fy,3,ST); ctx.fillStyle='#AA8830';ctx.fillRect(fx+ST-2,fy+1,1,ST-2); }
+      // Subtle damask pattern
+      ctx.fillStyle='rgba(160,30,30,0.25)';
+      if((d.x+d.y)%2===0){
+        ctx.fillRect(fx+ST/2-4,fy+ST/2-4,8,8);
+        ctx.fillStyle='rgba(200,160,64,0.08)';
+        ctx.fillRect(fx+ST/2-2,fy+ST/2-6,4,12);
+        ctx.fillRect(fx+ST/2-6,fy+ST/2-2,12,4);
+      }
+    }
+    else if(d.item==='chandelier'){
+      // ── CHANDELIER — ceiling-mounted with warm glow ───────────
+      const ft=_now/400;
+      // This is a floor-level decorative; draws "above" as if hanging from ceiling
+      // Warm light pool on the floor
+      ctx.fillStyle=`rgba(255,220,140,${0.06+Math.sin(ft*0.7)*0.02})`;
+      ctx.beginPath();ctx.arc(fx+ST/2,fy+ST/2,ST*1.5,0,Math.PI*2);ctx.fill();
+      ctx.fillStyle=`rgba(255,200,100,${0.04+Math.sin(ft*0.9)*0.015})`;
+      ctx.beginPath();ctx.arc(fx+ST/2,fy+ST/2,ST,0,Math.PI*2);ctx.fill();
+      // Chain shadow on floor
+      ctx.fillStyle='rgba(0,0,0,0.06)';
+      ctx.fillRect(fx+ST/2-1,fy+ST/2-8,2,16);
+      // Chandelier shadow silhouette on floor
+      ctx.fillStyle='rgba(0,0,0,0.04)';
+      ctx.fillRect(fx+ST/2-12,fy+ST/2-1,24,2);
+      // Candle glow spots
+      ctx.fillStyle='rgba(255,200,80,0.08)';
+      ctx.beginPath();ctx.arc(fx+ST/2-8,fy+ST/2,6,0,Math.PI*2);ctx.fill();
+      ctx.beginPath();ctx.arc(fx+ST/2+8,fy+ST/2,6,0,Math.PI*2);ctx.fill();
+    }
     else if(d.item==='town_seal'){
       // ── TOWN SEAL — circular ₿ emblem on floor (walkable) ────
       // Check neighbours for connected rendering

--- a/web/index.html
+++ b/web/index.html
@@ -25,12 +25,12 @@ canvas { display: block; width: 100vw; height: 100vh; image-rendering: pixelated
     invoked from inside gameLoop/draw at runtime — after this script
     has executed — so the forward reference is safe.
 -->
-<script src="sprites.js?v=59"></script>
-<script src="music.js?v=59"></script>
-<script src="game_audio.js?v=59"></script>
-<script src="game_quests.js?v=59"></script>
-<script src="game_mines.js?v=59"></script>
-<script src="game.js?v=59"></script>
-<script src="game_render.js?v=59"></script>
+<script src="sprites.js?v=60"></script>
+<script src="music.js?v=60"></script>
+<script src="game_audio.js?v=60"></script>
+<script src="game_quests.js?v=60"></script>
+<script src="game_mines.js?v=60"></script>
+<script src="game.js?v=60"></script>
+<script src="game_render.js?v=60"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Complete Town Hall v2 redesign with real civic grandeur:
- **Stained glass ₿ window** (4 tiles) behind desk — red/blue/green/gold glass panes with animated light beams casting coloured light onto the floor
- **Stone columns** with classical capitals, fluting, and scroll details at corners
- **Rich crimson carpet runner** with gold trim down the centre aisle (seamless tiling)
- **Chandelier** casting warm animated light pool on the floor
- **Open layout** — paired council benches flanking the carpet, not cramming the space
- **Mayor repositioned** in front of desk, more visible
- Kept: Uncle Toshi portrait, whitepaper, bookshelves, lectern with ₿, wall sconces

## Test plan
- [ ] Enter Town Hall — should feel grand and civic, not like a warehouse
- [ ] Stained glass should have animated light beams below it
- [ ] Walk on red carpet (walkable) and chandelier light
- [ ] Mayor visible and talkable
- [ ] Columns at corners give architectural weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)